### PR TITLE
Multiple code improvements - squid:S1854, squid:S1068, squid:S1481, squid:S1764

### DIFF
--- a/app/src/main/java/com/stevenschoen/putionew/fragments/Files.java
+++ b/app/src/main/java/com/stevenschoen/putionew/fragments/Files.java
@@ -59,7 +59,6 @@ public class Files extends NoClipSupportDialogFragment implements SwipeRefreshLa
 	private static final int VIEWMODE_LOADING = 3;
 	private static final int VIEWMODE_EMPTY = 4;
 	private static final int VIEWMODE_LISTORLOADING = 5;
-	private int viewMode = VIEWMODE_LIST;
 
     private long highlightFileId = -1;
 

--- a/app/src/main/java/com/stevenschoen/putionew/model/responses/PutioTransferFileUploadResponse.java
+++ b/app/src/main/java/com/stevenschoen/putionew/model/responses/PutioTransferFileUploadResponse.java
@@ -1,7 +1,4 @@
 package com.stevenschoen.putionew.model.responses;
 
-import com.stevenschoen.putionew.model.transfers.PutioTransfer;
-
 public class PutioTransferFileUploadResponse extends BasePutioResponse {
-	private PutioTransfer transfer;
 }

--- a/app/src/main/java/com/stevenschoen/putionew/model/transfers/PutioTransfer.java
+++ b/app/src/main/java/com/stevenschoen/putionew/model/transfers/PutioTransfer.java
@@ -28,7 +28,7 @@ public class PutioTransfer implements Parcelable {
 					&& equalsNullSafe(transfer.createdTime, createdTime) && transfer.extract == extract
 					&& transfer.currentRatio == currentRatio && transfer.downSpeed == downSpeed
 					&& transfer.upSpeed == upSpeed && transfer.percentDone == percentDone
-					&& equalsNullSafe(transfer.status, status) && equalsNullSafe(transfer.status, status)
+					&& equalsNullSafe(transfer.status, status)
 					&& transfer.saveParentId == saveParentId);
 		}
 		return super.equals(o);

--- a/app/src/main/java/com/stevenschoen/putionew/tv/TvGridFragment.java
+++ b/app/src/main/java/com/stevenschoen/putionew/tv/TvGridFragment.java
@@ -23,7 +23,6 @@ import rx.functions.Action1;
  * Created by simonreggiani on 15-01-11.
  */
 public class TvGridFragment extends android.support.v17.leanback.app.VerticalGridSupportFragment {
-    private static final String TAG = "VerticalGridFragment";
 
     private static final int NUM_COLUMNS = 3;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1068 - Unused private fields should be removed.
squid:S1481 - Unused local variables should be removed.
squid:S1764 - Identical expressions should not be used on both sides of a binary operator.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S1764
Please let me know if you have any questions.
George Kankava